### PR TITLE
Mac support tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer "Josh Sunnex <jsunnex@gmail.com>"
 ###############################################################
 
 # Version of Tizonia to be installed
-ARG TIZONIA_VERSION=0.19.0-1
+ARG TIZONIA_VERSION=0.20.0-1
 
 # Configure username for executing process
 ENV UNAME tizonia

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ ARG PYTHON_DEPENDENCIES=" \
         fuzzywuzzy>=0.17.0 \
         gmusicapi>=12.1.1 \
         pafy>=0.5.4 \
-        pycountry>=18.12.8 \
+        pycountry>=19.8.18 \
         python-levenshtein>=0.12.0 \
         soundcloud>=0.5.0 \
         spotipy>=2.4.4 \
         titlecase>=0.12.0 \
-        youtube-dl>=2019.8.2 \
+        youtube-dl>=2019.9.12.1 \
     "
 
 # Build Dependencies (not required in final image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN \
     && \
     echo "**** Add additional apt repos ****" \
         && curl -ksSL 'http://apt.mopidy.com/mopidy.gpg' | apt-key add - \
-        && echo "deb http://apt.mopidy.com/ stable main contrib non-free" > /etc/apt/sources.list.d/libspotify.list \
+        && echo "deb http://apt.mopidy.com/ stretch main contrib non-free" > /etc/apt/sources.list.d/libspotify.list \
         && curl -ksSL 'https://bintray.com/user/downloadSubjectPublicKey?username=tizonia' | apt-key add - \
         && echo "deb https://dl.bintray.com/tizonia/ubuntu bionic main" > /etc/apt/sources.list.d/tizonia.list \
         && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer "Josh Sunnex <jsunnex@gmail.com>"
 ###############################################################
 
 # Version of Tizonia to be installed
-ARG TIZONIA_VERSION=0.18.0-1
+ARG TIZONIA_VERSION=0.19.0-1
 
 # Configure username for executing process
 ENV UNAME tizonia
@@ -19,6 +19,7 @@ ARG PYTHON_DEPENDENCIES=" \
         fuzzywuzzy>=0.17.0 \
         gmusicapi>=12.1.1 \
         pafy>=0.5.4 \
+        plexapi>=3.0.0 \
         pycountry>=19.8.18 \
         python-levenshtein>=0.12.0 \
         soundcloud>=0.5.0 \
@@ -34,11 +35,11 @@ ARG BUILD_DEPENDENCIES=" \
         gnupg \
         libffi-dev \
         libssl-dev \
-        python-dev \
-        python-pip \
-        python-pkg-resources \
-        python-setuptools \
-        python-wheel \
+        python3-dev \
+        python3-pip \
+        python3-pkg-resources \
+        python3-setuptools \
+        python3-wheel \
     "
 
 ###############################################################
@@ -62,10 +63,11 @@ RUN \
         && apt-get update \
     && \
     echo "**** Install python dependencies ****" \
-        && python -m pip install --no-cache-dir --upgrade ${PYTHON_DEPENDENCIES} \
+        && python3 -m pip install --no-cache-dir --upgrade ${PYTHON_DEPENDENCIES} \
     && \
     echo "**** Install tizonia ****" \
         && apt-get install -y \
+            python3-distutils \
             pulseaudio-utils \
             libspotify12 \
             tizonia-all=${TIZONIA_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ARG TIZONIA_VERSION=0.20.0-1
 
 # Configure username for executing process
 ENV UNAME tizonia
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # A list of dependencies installed with
 ARG PYTHON_DEPENDENCIES=" \
@@ -54,6 +57,11 @@ RUN \
     echo "**** Install package build tools ****" \
         && apt-get install -y --no-install-recommends \
             ${BUILD_DEPENDENCIES} \
+            locales \
+    && \
+    echo "**** Generate necessary locales ****" \
+        && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+            locale-gen \
     && \
     echo "**** Add additional apt repos ****" \
         && curl -ksSL 'http://apt.mopidy.com/mopidy.gpg' | apt-key add - \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ docker-tizonia --youtube-audio-mix-search "Queen Official"
 
 ### Step 1)
 
-It is required that pulse audio to be installed via homebrew
+It is required that PulseAudio to be installed via `homebrew`
 (`brew install pulseaudio`), and the following lines in
 `/usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa` to be uncommented:
 
@@ -54,7 +54,7 @@ load-module module-native-protocol-tcp
 
 ### Step 2)
 
-Too adjust the device being used for output, bring up a list of possible output devices and
+To choose the device being used for output, bring up a list of possible output devices and
 select one as the default sink:
 
 ```bash
@@ -71,8 +71,8 @@ Start the Pulseaudio daemon:
 pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
 ```
 
-You should now be able to utilize the docker container to route audio from the docker container
-to the host machine!
+You should now be able to utilize the `docker-tizonia` script to route audio from the docker
+container to the host machine!
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,6 @@
 
 Containerized [**Tizonia**](http://www.tizonia.org/) cloud music player that uses the host's sound system.
 
-## Mac Support
-## Step 1) 
-
-It is required that pulse audio to be installed via homebrew, and the following lines in /usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa to be uncommented:
-
-load-module module-esound-protocol-tcp
-load-module module-native-protocol-tcp
-
-## Step 2) 
-
-Too adjust the device being used for output, bring up a list of possible output devices and select one as the default sink:
-
-pactl list short sinks
-
-pacmd set-default-sink n (Where N is the chosen output number)
-
-## Step 3) 
-
-Start the Pulseaudio daemon:
-
-pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
-
-You should now be able to utilize the docker container to route audio from the docker-image to the client device!
-
 ## Audio Output
 
 Tizonia connects as a client directly to the hosts PulseAudio server and uses
@@ -39,23 +15,7 @@ its use.
 
 ## Launch Command
 
-Use the convenience script [docker-tizonia](docker-tizonia):
-
-``` bash
-#!/bin/bash
-
-USER_ID=$(id -u);
-GROUP_ID=$(id -g);
-
-docker run -it --rm \
-    -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
-    --volume=${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse \
-    --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
-    --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
-    --name tizonia \
-    tizonia/docker-tizonia "$@";
-
-```
+Use the convenience script [docker-tizonia](docker-tizonia).
 
 The script bind mounts the host's '$HOME/.config/tizonia' to make
 'tizonia.conf' available inside the container.
@@ -78,6 +38,41 @@ $ sudo install docker-tizonia /usr/local/bin
 $ docker-tizonia --youtube-audio-mix-search "Queen Official"
 
 ```
+
+## Mac Support
+
+### Step 1)
+
+It is required that pulse audio to be installed via homebrew
+(`brew install pulseaudio`), and the following lines in
+`/usr/local/Cellar/pulseaudio/13.0/etc/pulse/default.pa` to be uncommented:
+
+```
+load-module module-esound-protocol-tcp
+load-module module-native-protocol-tcp
+```
+
+### Step 2)
+
+Too adjust the device being used for output, bring up a list of possible output devices and
+select one as the default sink:
+
+```bash
+pactl list short sinks
+
+pacmd set-default-sink n  # where n is the chosen output number
+```
+
+### Step 3)
+
+Start the Pulseaudio daemon:
+
+```bash
+pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+```
+
+You should now be able to utilize the docker container to route audio from the docker container
+to the host machine!
 
 # License
 

--- a/docker-tizonia
+++ b/docker-tizonia
@@ -3,9 +3,18 @@
 USER_ID=$(id -u);
 GROUP_ID=$(id -g);
 
-docker run --rm -v $HOME:$HOME -w $HOME -it\
-	-e PULSE_SERVER=docker.for.mac.localhost\
+if uname -s | grep -iq "Darwin" ; then
+  pulse_server=docker.for.mac.localhost
+  runtime_dir="$HOME"
+else
+  pulse_server=unix:"${XDG_RUNTIME_DIR}/pulse/native"
+  runtime_dir="${XDG_RUNTIME_DIR}/pulse"
+fi
+
+docker run -it --rm \
+    -e PULSE_SERVER="$pulse_server" \
+    --volume="$runtime_dir":"$runtime_dir" \
     --volume="${HOME}/.config/tizonia":/home/tizonia/.config/tizonia \
-    --volume "${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
+    --volume="${HOME}/.config/pulse/cookie":/home/tizonia/.config/pulse/cookie \
     --name tizonia \
     tizonia/docker-tizonia "$@";


### PR DESCRIPTION
Hi @thed24 !

I'm starting to work as a collaborator / maintainer on [`docker-tizonia`](https://github.com/tizonia/docker-tizonia), and as Mac support is a big thing people ask for in Tizonia I'm looking forward to getting your PR merged in as an option for people.

Thanks for all your work and investigation in your fork! I just had a couple tweaks I wanted to suggest. The README changes are largely formatting and content ordering, I left your content pretty much as is. The `docker-tizonia` script changes are just so that the same version of the script will work equally well under Mac and Linux machines.

This might seem a little roundabout, but I had quite a few specific changes in mind and I didn't want to clobber the `master` branch in your fork, so I've opened this PR against your fork so you can check it out (as I myself don't own a Mac). If everything looks good to you we can merge this PR into your fork and then I'll merge your PR in the upstream repo reflecting both our changes.

Please take a glance at this and let me know if you have any issues or feedback.

Thanks!